### PR TITLE
usersetup.py: Pass "--preserve-env" to sudo

### DIFF
--- a/sudoers.usersetup
+++ b/sudoers.usersetup
@@ -1,3 +1,3 @@
 usersetup ALL=NOPASSWD: /usr/bin/restrict_groupadd.sh
 usersetup ALL=NOPASSWD: /usr/bin/restrict_useradd.sh
-usersetup ALL = (sdkuser) NOPASSWD: /usr/bin/esdk-launch.py
+usersetup ALL = (sdkuser) NOPASSWD:SETENV: /usr/bin/esdk-launch.py

--- a/usersetup.py
+++ b/usersetup.py
@@ -64,5 +64,5 @@ subprocess.check_call(cmd.split(), stdout=sys.stdout, stderr=sys.stderr)
 
 usercmd = "{} {}".format(args.cmd, " ".join(args.args))
 
-cmd = ("sudo -H -u {} ".format(args.username) + usercmd).split()
+cmd = ("sudo --preserve-env --set-home -u {} ".format(args.username) + usercmd).split()
 os.execvp(cmd[0], cmd)


### PR DESCRIPTION
Without this argument, any environment variables passed into the
container using -e, for instance -e "http_proxy=mrproxy.mine.com:8080",
would be dropped when we switched users.  This also puts SETENV into
the sudoers file so we are allowed to pass on the environment.

Signed-off-by: bavery brian.avery@intel.com
