### PR TITLE
Dockerfile: Change to ubuntu-16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ext sdk container
 #
-FROM crops/yocto:ubuntu-14.04-base
+FROM crops/yocto:ubuntu-16.04-base
 
 USER root
 


### PR DESCRIPTION
poky master is dropping support for 14.04 and supports 16.04.  We will
try to keep up with the intersection of poky master and Ubuntu LTS.

Signed-off-by: brian avery <brian.avery@intel.com>