### PR TITLE
restrict_useradd: Allow any uid other than 0

### DIFF
--- a/restrict_useradd.sh
+++ b/restrict_useradd.sh
@@ -25,8 +25,8 @@ if [ "$4" != "" ]; then
     skelarg="-k $4"
 fi
 
-if [ $uid -lt 101 ]; then
-    echo "Refusing to use a uid less than 101"
+if [ $uid -eq 0 ]; then
+    echo "Refusing to use a uid of 0 (root)"
     exit 1
 elif [ $gid -eq 0 ]; then
     echo "Refusing to use a gid of 0"

--- a/tests/test_restrict_useradd.py
+++ b/tests/test_restrict_useradd.py
@@ -12,14 +12,14 @@ def test_fail_gid():
     assert "Refusing to use a gid of 0" in result.stdout.decode()
 
 
-uids = [0, 100]
-@pytest.mark.parametrize("uid", uids)
-def test_fail_uid(uid):
-    cmd = shlex.split("./restrict_useradd.sh {} 0 somegroup".format(uid))
+# Changed restriction to only disallow root (0) due to
+# various win/mac hypervisor issues
+def test_fail_uid():
+    cmd = shlex.split("./restrict_useradd.sh {} 0 somegroup".format(0))
     result = subprocess.run(cmd, stdout=subprocess.PIPE, check=False)
 
     assert result.returncode != 0
-    assert "Refusing to use a uid less than 101" in result.stdout.decode()
+    assert "Refusing to use a uid of 0" in result.stdout.decode()
 
 
 useskelarg = [ True, False ]
@@ -38,7 +38,6 @@ def setup_env_and_cmd():
         cmd = cmd + " /myskel"
 
     yield shlex.split(cmd)
-    
     os.environ = oldenv
 
 


### PR DESCRIPTION
While linux tends to keep uid > 100 for users, it turns out that the
hypervisor on mac has decided to translate the existing mac users to
uids of < 100. All we can be certain of is that a uid 0 should be
refused.

Signed-off-by: brian avery <brian.avery@intel.com>