### PR TITLE
restrict_*.sh: Changed to elif to avoid nuisance warnings

### DIFF
--- a/restrict_groupadd.sh
+++ b/restrict_groupadd.sh
@@ -24,6 +24,6 @@ groupname=$2
 if [ $gid -eq 0 ]; then
     echo "Refusing to use a gid of 0"
     exit 1
-else
+elif [ ! $(getent group pokyuser) ]; then
     groupadd -o -g $gid "$groupname"
 fi

--- a/restrict_useradd.sh
+++ b/restrict_useradd.sh
@@ -31,6 +31,6 @@ if [ $uid -eq 0 ]; then
 elif [ $gid -eq 0 ]; then
     echo "Refusing to use a gid of 0"
     exit 1
-else
+elif [ ! $(getent passwd pokyuser) ]; then
     useradd -N -g $gid -m $skelarg -o -u $uid "$username"
 fi


### PR DESCRIPTION
Running either useradd or groupadd when the user or group
is already present will generate a nuisance message. This
change checks for the presence of the group or user,
respectively, ahead of attempting the command.

Signed-off-by: Thomas Goodwin <btgoodwin@geontech.com>