### PR TITLE
Update apt-get in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY sudoers.usersetup /etc/
 RUN userdel -r yoctouser && \
     groupadd -g 70 usersetup && \
     useradd -N -m -u 70 -g 70 usersetup && \
+    apt-get update && \
     apt-get -y install curl sudo && \
     echo "#include /etc/sudoers.usersetup" >> /etc/sudoers && \
     chmod 755 /usr/bin/usersetup.py \


### PR DESCRIPTION
I failed to build the Docker image so I added a fix and thought that perhaps it would be relevant to include it upstream.
The error I got was the following:

```
 => ERROR [4/4] RUN userdel -r yoctouser &&     groupadd -g 70 usersetup &&     useradd -N -m -u 70 -g 70 usersetup &&     apt-get -y install curl sudo &&     echo "#include /etc/sudoers.usersetup" >> /etc/sudoers &&     ch  1.8s
------
 > [4/4] RUN userdel -r yoctouser &&     groupadd -g 70 usersetup &&     useradd -N -m -u 70 -g 70 usersetup &&     apt-get -y install curl sudo &&     echo "#include /etc/sudoers.usersetup" >> /etc/sudoers &&     chmod 755 /usr/bin/usersetup.py         /usr/bin/esdk-launch.py         /usr/bin/esdk-entry.py         /usr/bin/restrict_groupadd.sh         /usr/bin/restrict_useradd.sh:
#6 0.278 userdel: yoctouser mail spool (/var/mail/yoctouser) not found
#6 0.374 Reading package lists...
#6 1.186 Building dependency tree...
#6 1.317 Reading state information...
#6 1.429 sudo is already the newest version (1.8.16-0ubuntu1.9).
#6 1.429 The following packages were automatically installed and are no longer required:
#6 1.430   libexpat1-dev libpython3-dev libpython3.5 libpython3.5-dev python-pip-whl
#6 1.430   python3-dev python3-pkg-resources python3-setuptools python3-wheel
#6 1.430   python3.5-dev
#6 1.430 Use 'apt autoremove' to remove them.
#6 1.432 The following NEW packages will be installed:
#6 1.433   curl
#6 1.531 0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
#6 1.531 Need to get 139 kB of archives.
#6 1.531 After this operation, 340 kB of additional disk space will be used.
#6 1.531 Err:1 http://security.ubuntu.com/ubuntu xenial-security/main amd64 curl amd64 7.47.0-1ubuntu2.16
#6 1.531   404  Not Found [IP: 91.189.88.142 80]
#6 1.732 Err:1 http://security.ubuntu.com/ubuntu xenial-security/main amd64 curl amd64 7.47.0-1ubuntu2.16
#6 1.732   404  Not Found [IP: 91.189.88.142 80]
#6 1.734 E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.47.0-1ubuntu2.16_amd64.deb  404  Not Found [IP: 91.189.88.142 80]
#6 1.734
#6 1.734 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
executor failed running [/bin/sh -c userdel -r yoctouser &&     groupadd -g 70 usersetup &&     useradd -N -m -u 70 -g 70 usersetup &&     apt-get -y install curl sudo &&     echo "#include /etc/sudoers.usersetup" >> /etc/sudoers &&     chmod 755 /usr/bin/usersetup.py         /usr/bin/esdk-launch.py         /usr/bin/esdk-entry.py         /usr/bin/restrict_groupadd.sh         /usr/bin/restrict_useradd.sh]: exit code: 100
```

