### PR TITLE
github/workflows: build every Saturday at 02:12 UTC

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -8,6 +8,10 @@ on:
   # Allow for manually running
   workflow_dispatch:
 
+  # Run at 02:12 UTC every Saturday
+  schedule:
+    - cron: '12 2 * * 6'
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our old TravisCI workflow updated the upstream distro packages
once a week. Re-enable that behavior..

Reference:
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events

Signed-off-by: Tim Orling <tim.orling@konsulko.com>