### PR TITLE
Deploy on 'schedule'

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -8,6 +8,10 @@ on:
   # Allow for manually running
   workflow_dispatch:
 
+  # Run at 02:12 UTC every Saturday
+  schedule:
+    - cron: '12 2 * * 6'
+
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,7 @@ set -e
 
 # Don't deploy on pull requests because it could just be junk code that won't
 # get merged
-if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "schedule" ) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
     echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
     docker push ${REPO}:latest
 else


### PR DESCRIPTION

Since 'github/workflows: build every Saturday at 02:12 UTC' builds were
properly being scheduled, but not deployed.