### PR TITLE
Ubuntu 18.04 and SPDX header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
 # Copyright (C) 2015-2016 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-#
 # ext sdk container
 #
-FROM crops/yocto:ubuntu-16.04-base
+FROM crops/yocto:ubuntu-18.04-base
 
 USER root
 


### PR DESCRIPTION
Base container on yocto-dockerfiles Ubuntu-18.04 and replace license in header with SPDX-License-Identifier