### PR TITLE
test_dumb_init: fix syntax warning about 'is'

### DIFF
--- a/tests/test_dumb_init.py
+++ b/tests/test_dumb_init.py
@@ -26,17 +26,17 @@ def remove_container(name):
 
 def run_container(testimage, hostdir, name="", workdir="/workdir", url=""):
     print("{}, {}, {}, {}".format(testimage, hostdir, workdir, url))
-    if url is "":
+    if url == "":
         urlarg = ""
     else:
         urlarg = "--url {}".format(url)
 
-    if workdir is "":
+    if workdir == "":
         workdirarg = ""
     else:
         workdirarg = "--workdir {}".format(workdir)
 
-    if name is "":
+    if name == "":
         namearg = ""
     else:
         namearg = "--name {}".format(name)


### PR DESCRIPTION
Use == instead of 'is'.

Fixes:

=============================== warnings summary =============================== tests/test_dumb_init.py:29
  /home/runner/work/extsdk-container/extsdk-container/tests/test_dumb_init.py:29: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if url is "":

tests/test_dumb_init.py:34
  /home/runner/work/extsdk-container/extsdk-container/tests/test_dumb_init.py:34: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if workdir is "":

tests/test_dumb_init.py:39
  /home/runner/work/extsdk-container/extsdk-container/tests/test_dumb_init.py:39: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if name is "":

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html ======================== 7 passed, 3 warnings in 1.35s =========================

Signed-off-by: Tim Orling <tim.orling@konsulko.com>